### PR TITLE
WL-2599 When we have a problem with LDAP throw error.

### DIFF
--- a/api/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupException.java
+++ b/api/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupException.java
@@ -1,17 +1,25 @@
 package uk.ac.ox.oucs.vle;
 
+/**
+ * Exception to be thrown when something has gone wrong.
+ *
+ */
 public class ExternalGroupException extends Exception {
 
 	private static final long serialVersionUID = 1L;
 
 	public enum Type {SIZE_LIMIT, UNKNOWN}
 	
-	private Type type;
+	private Type type = Type.UNKNOWN;
 	
 	public ExternalGroupException(Type type) {
 		this.type = type;
 	}
 	
+	public ExternalGroupException(String message, Exception exception) {
+		super(message, exception);
+	}
+
 	public Type getType() {
 		return type;
 	}

--- a/api/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManager.java
+++ b/api/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManager.java
@@ -3,6 +3,15 @@ package uk.ac.ox.oucs.vle;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * The external group manager allows for finding external groups of users.
+ * Then once an external group of users has been found a mapped group can 
+ * be created which assigns a role to that external group of users and creates
+ * and ID for the mapped group which can be assigned to a site.
+ * 
+ * @author buckett
+ *
+ */
 public interface ExternalGroupManager {
 
 	public List<ExternalGroup> search(String query) throws ExternalGroupException;
@@ -11,9 +20,9 @@ public interface ExternalGroupManager {
 
 	public List<ExternalGroupNode> findNodes(String path) throws ExternalGroupException;
 
-	public ExternalGroup findExternalGroup(String externalGroupId);
+	public ExternalGroup findExternalGroup(String externalGroupId) throws ExternalGroupException;
 	
-	public Map<String, String> getGroupRoles(String userId);
+	public Map<String, String> getGroupRoles(String userId) throws ExternalGroupException;
 	
 	/**
 	 * Find the role for the mapped group.
@@ -27,8 +36,9 @@ public interface ExternalGroupManager {
 	 * @param externalGroupId The external ID of the new group.
 	 * @param role The role to assign all participants of the group.
 	 * @return The ID of the newly created group, or if it already exists the existing ID.
+	 * @throws ExternalGroupException If there was a problem creating the group.
 	 */
-	public String addMappedGroup(String externalGroupId, String role);
+	public String addMappedGroup(String externalGroupId, String role) throws ExternalGroupException;
 	
 	/**
 	 * Get the external group ID for a mapped group.

--- a/api/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManagerCover.java
+++ b/api/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManagerCover.java
@@ -39,7 +39,7 @@ public class ExternalGroupManagerCover {
 		return service.search(terms);
 	}
 	
-	public ExternalGroup findExternalGroup(String externalGroupId) {
+	public ExternalGroup findExternalGroup(String externalGroupId) throws ExternalGroupException {
 		ExternalGroupManager service = getInstance();
 		if (service == null) return null;;
 		
@@ -53,7 +53,7 @@ public class ExternalGroupManagerCover {
 		return service.findExternalGroupId(mappedGroupId);
 	}
 	
-	public String addMappedGroup(String externalGroupId, String role) {
+	public String addMappedGroup(String externalGroupId, String role) throws ExternalGroupException {
 		ExternalGroupManager service = getInstance();
 		if (service == null) return null;
 		


### PR DESCRIPTION
Basically we should be throwing serious problems with LDAP back up the stack so that we don't mask problems. This caused an issue where groups were returned as empty when LDAP became unavailable and this caused site groups to have members removed from them. The LDAP became available again the groups memberships didn't reappear.
