### PR TITLE
WL-4126 Make group browser more reliable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .project
 .settings
 .springBeans
+integration-tests/src/test/resources/test.properties

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManagerImpl.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManagerImpl.java
@@ -165,6 +165,8 @@ public class ExternalGroupManagerImpl implements ExternalGroupManager {
 			return courseOwnersFilter;
 		}
 
+		// A default filter that shows all departments (even those without courses)
+		courseOwnersFilter = OXFORD_UNIT_SITS_CODE+ "=*";
 		// A default of all units.
 		LDAPConnection conn = null;
 		try {
@@ -186,8 +188,6 @@ public class ExternalGroupManagerImpl implements ExternalGroupManager {
 			}
 		} catch (LDAPException lde) {
 			log.error("Failed to find course owners.", lde);
-			// A default filter that shows all departments (even those without courses)
-			courseOwnersFilter = OXFORD_UNIT_SITS_CODE+ "=*";
 		} finally {
 			returnConnection(conn);
 		}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManagerImpl.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManagerImpl.java
@@ -171,7 +171,9 @@ public class ExternalGroupManagerImpl implements ExternalGroupManager {
 		LDAPConnection conn = null;
 		try {
 			conn = getConnection();
-			LDAPSearchResults searchResults = conn.search(COURSE_BASE, LDAPConnection.SCOPE_SUB, OXFORD_COURSE_OWNER + "=*", new String[]{OXFORD_COURSE_OWNER}, false);
+			// The objectClass filter means that many fewer items are queried and so speeds up the filter.
+			String filter = String.format("(&(%s=*)(objectClass=groupstoreOrganizationalUnit))", OXFORD_COURSE_OWNER);
+			LDAPSearchResults searchResults = conn.search(COURSE_BASE, LDAPConnection.SCOPE_SUB, filter, new String[]{OXFORD_COURSE_OWNER}, false);
 			Set<String> owners = new HashSet<>();
 			while (searchResults.hasMore()) {
 				LDAPEntry result = searchResults.next();

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManagerImpl.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/ExternalGroupManagerImpl.java
@@ -2,13 +2,7 @@ package uk.ac.ox.oucs.vle;
 
 import java.text.MessageFormat;
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -171,28 +165,33 @@ public class ExternalGroupManagerImpl implements ExternalGroupManager {
 			return courseOwnersFilter;
 		}
 
-		String oxfordCourseOwners = "";
+		// A default of all units.
 		LDAPConnection conn = null;
 		try {
 			conn = getConnection();
 			LDAPSearchResults searchResults = conn.search(COURSE_BASE, LDAPConnection.SCOPE_SUB, OXFORD_COURSE_OWNER + "=*", new String[]{OXFORD_COURSE_OWNER}, false);
+			Set<String> owners = new HashSet<>();
 			while (searchResults.hasMore()) {
 				LDAPEntry result = searchResults.next();
 				String name = result.getAttribute(OXFORD_COURSE_OWNER).getStringValue();
-				oxfordCourseOwners = oxfordCourseOwners + "(" + OXFORD_UNIT_SITS_CODE + "=" + name + ")";
+				owners.add(name);
 			}
-			oxfordCourseOwners = "(|" + oxfordCourseOwners + ")";
+			if (owners.size() > 0){
+				StringBuilder oxfordCourseOwners = new StringBuilder();
+				for (String owner: owners) {
+					oxfordCourseOwners.append("(").append(OXFORD_UNIT_SITS_CODE).append("=").append(owner).append(")");
+				}
+				courseOwnersFilter = "(|" + oxfordCourseOwners.toString() + ")";
+				courseOwnersCache.put(COURSE_OWNERS_CACHE, courseOwnersFilter);
+			}
 		} catch (LDAPException lde) {
 			log.error("Failed to find course owners.", lde);
-			throw new ExternalGroupException(Type.UNKNOWN);
+			// A default filter that shows all departments (even those without courses)
+			courseOwnersFilter = OXFORD_UNIT_SITS_CODE+ "=*";
 		} finally {
 			returnConnection(conn);
 		}
-
-		if (!oxfordCourseOwners.isEmpty()){
-			courseOwnersCache.put(COURSE_OWNERS_CACHE, oxfordCourseOwners);
-		}
-		return oxfordCourseOwners;
+		return courseOwnersFilter;
 	}
 
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -83,6 +83,12 @@
 			<artifactId>spring-context</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -11,6 +11,28 @@
 	<artifactId>external-groups-test</artifactId>
 	<name>External Groups Integration Tests</name>
 	<packaging>jar</packaging>
+	<profiles>
+		<profile>
+			<!-- By default don't run the tests as they need configuration -->
+			<id>disable-by-default</id>
+			<activation>
+				<file>
+					<missing>${basedir}/src/test/resources/test.properties</missing>
+				</file>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<dependencies>
 		<dependency>
 			<groupId>uk.ac.ox.oucs</groupId>
@@ -62,4 +84,21 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<!-- As we don't actually have anything other than tests to get rid of the maven
+				     warning we switch to using the test-jar goal so there is an artifact that isn't empty-->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/integration-tests/src/test/java/uk/ac/ox/oucs/vle/MockUserDirectoryServices.java
+++ b/integration-tests/src/test/java/uk/ac/ox/oucs/vle/MockUserDirectoryServices.java
@@ -7,14 +7,7 @@ import org.sakaiproject.entity.api.HttpAccess;
 import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.time.api.Time;
-import org.sakaiproject.user.api.User;
-import org.sakaiproject.user.api.UserAlreadyDefinedException;
-import org.sakaiproject.user.api.UserDirectoryService;
-import org.sakaiproject.user.api.UserEdit;
-import org.sakaiproject.user.api.UserIdInvalidException;
-import org.sakaiproject.user.api.UserLockedException;
-import org.sakaiproject.user.api.UserNotDefinedException;
-import org.sakaiproject.user.api.UserPermissionException;
+import org.sakaiproject.user.api.*;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -22,6 +15,11 @@ public class MockUserDirectoryServices implements UserDirectoryService {
 
 	@Override
 	public PasswordRating validatePassword(String s, User user) {
+		return null;
+	}
+
+	@Override
+	public PasswordPolicyProvider getPasswordPolicy() {
 		return null;
 	}
 

--- a/integration-tests/src/test/java/uk/ac/ox/oucs/vle/TestExternalGroups.java
+++ b/integration-tests/src/test/java/uk/ac/ox/oucs/vle/TestExternalGroups.java
@@ -1,15 +1,22 @@
 package uk.ac.ox.oucs.vle;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.sakaiproject.memory.api.Cache;
+import org.sakaiproject.memory.api.MemoryService;
 import org.sakaiproject.user.api.User;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.AbstractDependencyInjectionSpringContextTests;
 
 public class TestExternalGroups extends AbstractDependencyInjectionSpringContextTests {
 
-	private ExternalGroupManager groupManager;
+	private ExternalGroupManagerImpl groupManager;
 
 	@Override
 	protected String[] getConfigLocations() {
@@ -18,7 +25,35 @@ public class TestExternalGroups extends AbstractDependencyInjectionSpringContext
 	
 	protected void onSetUp() {
 		ApplicationContext context = getApplicationContext();
-		groupManager = (ExternalGroupManager)context.getBean("ExternalGroupManager");
+		groupManager = (ExternalGroupManagerImpl) context.getBean("ExternalGroupManager");
+
+		Cache cache = Mockito.mock(Cache.class);
+		final Map<Object, Object> map = new HashMap<>();
+		Mockito.doAnswer(new Answer() {
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				Object[] arguments = invocation.getArguments();
+				map.put(arguments[0], arguments[1]);
+				return Void.TYPE;
+			}
+		}).when(cache).put(Mockito.any(), Mockito.any());
+		Mockito.doAnswer(new Answer() {
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				Object[] arguments = invocation.getArguments();
+				return map.get(arguments[0]);
+			}
+		}).when(cache).get(Mockito.any());
+
+		MemoryService memoryService = Mockito.mock(MemoryService.class);
+		Mockito.when(memoryService.newCache(Mockito.anyString())).thenReturn(cache);
+
+		groupManager.setMemoryService(memoryService);
+
+		MappedGroupDao mappedGroupDao = Mockito.mock(MappedGroupDao.class);
+		groupManager.setMappedGroupDao(mappedGroupDao);
+
+		groupManager.init();
 	}
 	
 	public void testSearch() throws Exception {
@@ -37,8 +72,11 @@ public class TestExternalGroups extends AbstractDependencyInjectionSpringContext
 			count++;
 		}
 		assertTrue(count > 0);
-	}	
-	
+	}
 
+	public void testBrowseCourseDepartments() throws Exception {
+		List<ExternalGroupNode> groups = groupManager.findNodes(ExternalGroupManagerImpl.COURSES);
+		assertFalse(groups.isEmpty());
+	}
 
 }

--- a/integration-tests/src/test/java/uk/ac/ox/oucs/vle/TestExternalGroups.java
+++ b/integration-tests/src/test/java/uk/ac/ox/oucs/vle/TestExternalGroups.java
@@ -1,9 +1,6 @@
 package uk.ac.ox.oucs.vle;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -79,4 +76,18 @@ public class TestExternalGroups extends AbstractDependencyInjectionSpringContext
 		assertFalse(groups.isEmpty());
 	}
 
+	public void testWalkTree() throws Exception {
+		// Takes about 3 minutes
+		Queue<ExternalGroupNode> queue = new ArrayDeque<>();
+		queue.addAll(groupManager.findNodes(null));
+		while (!queue.isEmpty()) {
+			ExternalGroupNode node = queue.poll();
+			System.out.println(node.getPath());
+			// TODO Current if you attempt to ask for the nodes and it has groups you get an error, it shouldn't.
+			if (!node.hasGroup()) {
+				List<ExternalGroupNode> nodes = groupManager.findNodes(node.getPath());
+				queue.addAll(nodes);
+			}
+		}
+	}
 }

--- a/integration-tests/src/test/java/uk/ac/ox/oucs/vle/TestExternalGroups.java
+++ b/integration-tests/src/test/java/uk/ac/ox/oucs/vle/TestExternalGroups.java
@@ -22,12 +22,12 @@ public class TestExternalGroups extends AbstractDependencyInjectionSpringContext
 	}
 	
 	public void testSearch() throws Exception {
-		List<ExternalGroup> groups = groupManager.search("Computing services");
-		assertTrue("Expected to find the OUCS group.", groups.size() > 0);
+		List<ExternalGroup> groups = groupManager.search(new String[]{"IT", "Services"});
+		assertTrue("Expected to find the IT Services group.", groups.size() > 0);
 	}
 	
 	public void testFindById() throws Exception {
-		ExternalGroup group = groupManager.findExternalGroup("oakUnitCode=oucs,ou=units,dc=oak,dc=ox,dc=ac,dc=uk");
+		ExternalGroup group = groupManager.findExternalGroup("oakUnitCode=itserv,ou=units,dc=oak,dc=ox,dc=ac,dc=uk");
 		assertNotNull(group);
 		Iterator<User> users = group.getMembers();
 		assertTrue(users.hasNext());

--- a/integration-tests/src/test/resources/example.test.properties
+++ b/integration-tests/src/test/resources/example.test.properties
@@ -1,0 +1,5 @@
+# Copy this file to test.properties and set values accordingly to run
+# integration tests against a read LDAP server
+ldap.server=server.example.com
+ldap.username=username
+ldap.password=password

--- a/integration-tests/src/test/resources/test.xml
+++ b/integration-tests/src/test/resources/test.xml
@@ -29,7 +29,8 @@
 	<bean id="MockUserDirectory" class="uk.ac.ox.oucs.vle.MockUserDirectoryServices">
 		
 	</bean>
-	
+
+	<!-- We don't init here as we need to inject the other services -->
 	<bean id="ExternalGroupManager" class="uk.ac.ox.oucs.vle.ExternalGroupManagerImpl">
 		<property name="ldapConnectionManager">
 			<ref bean="LDAPConnectionManager"/>

--- a/integration-tests/src/test/resources/test.xml
+++ b/integration-tests/src/test/resources/test.xml
@@ -8,22 +8,21 @@
 			<value>test.properties</value>
 		</property>
 	</bean>
+	<bean id="LdapConfigurationTest" class="uk.ac.ox.oucs.vle.LdapConfigurationTest">
+		<property name="autoBind" value="true"/>
+		<property name="secureConnection" value="true"/>
+		<property name="secureSocketFactory">
+			<!--					<bean class="com.novell.ldap.LDAPJSSEStartTLSFactory" />-->
+			<bean class="com.novell.ldap.LDAPJSSESecureSocketFactory" />
+		</property>
+		<property name="ldapHost" value="${ldap.host}"/>
+		<property name="ldapPort" value="636"/>
+		<property name="ldapUser" value="${ldap.username}"/>
+		<property name="ldapPassword" value="${ldap.password}"/>
+	</bean>
 
 	<bean id="LDAPConnectionManager" class="edu.amc.sakai.user.SimpleLdapConnectionManager">
-		<property name="config">
-			<bean class="uk.ac.ox.oucs.vle.LdapConfigurationTest">
-				<property name="autoBind" value="true"/>
-				<property name="secureConnection" value="true"/>
-				<property name="secureSocketFactory">
-<!--					<bean class="com.novell.ldap.LDAPJSSEStartTLSFactory" />-->
-					  <bean class="com.novell.ldap.LDAPJSSESecureSocketFactory" /> 
-				</property>
-				<property name="ldapHost" value="${ldap.host}"/>
-				<property name="ldapPort" value="636"/>
-				<property name="ldapUser" value="${ldap.username}"/>
-				<property name="ldapPassword" value="${ldap.password}"/>
-			</bean>
-		</property>
+		<property name="config" ref="LdapConfigurationTest"/>
 	</bean>
 		
 	<bean id="MockUserDirectory" class="uk.ac.ox.oucs.vle.MockUserDirectoryServices">

--- a/integration-tests/src/test/resources/test.xml
+++ b/integration-tests/src/test/resources/test.xml
@@ -3,6 +3,12 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
+	<bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
+		<property name="location">
+			<value>test.properties</value>
+		</property>
+	</bean>
+
 	<bean id="LDAPConnectionManager" class="edu.amc.sakai.user.SimpleLdapConnectionManager">
 		<property name="config">
 			<bean class="uk.ac.ox.oucs.vle.LdapConfigurationTest">
@@ -12,10 +18,10 @@
 <!--					<bean class="com.novell.ldap.LDAPJSSEStartTLSFactory" />-->
 					  <bean class="com.novell.ldap.LDAPJSSESecureSocketFactory" /> 
 				</property>
-				<property name="ldapHost" value="ldap.oak.ox.ac.uk"/>
+				<property name="ldapHost" value="${ldap.host}"/>
 				<property name="ldapPort" value="636"/>
-				<property name="ldapUser" value="cn=service/bit.oucs.ox.ac.uk,cn=oakInternalPrincipals,dc=oak,dc=ox,dc=ac,dc=uk"/>
-				<property name="ldapPassword" value=""/>
+				<property name="ldapUser" value="${ldap.username}"/>
+				<property name="ldapPassword" value="${ldap.password}"/>
 			</bean>
 		</property>
 	</bean>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
 		<module>api</module>
 		<module>hbm</module>
 		<module>impl</module>
+		<!-- This should be moved into the impl in the long run -->
+		<module>integration-tests</module>
 		<module>tool</module>
 	</modules>
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,3 +6,14 @@ Need to look at request filter for Sakai.
 Need to add in authorization checks.
 Helper done processing (servlet? which we can redirect to).
 
+
+Integration Tests
+=================
+
+There are some integration tests in the `integration-test` folder, these need
+to be configured to be used. To do this copy the `example.test.properties`
+file to `test.properties` inside the folder `src/test/resources`. If this file
+isn't present then the tests aren't run. This way they can be part of the
+standard build but they won't break the build when no credentials are
+available.
+

--- a/readme.txt
+++ b/readme.txt
@@ -30,3 +30,9 @@ setting the system propery:
 
 which gives a high level overview of the operations of of the library.
 
+To enable debugging logging on tests the simplest way it to just switch to SimpleLogging
+and enable debug logging on that class:
+
+    -Dorg.apache.commons.logging.simplelog.log.uk.ac.ox.oucs.vle.TestExternalGroups=debug \
+    -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog
+

--- a/readme.txt
+++ b/readme.txt
@@ -17,3 +17,16 @@ isn't present then the tests aren't run. This way they can be part of the
 standard build but they won't break the build when no credentials are
 available.
 
+
+Debugging
+=========
+
+The JLDAP library doesn't do proper logging but to get some debugging information
+out during development you can set system properties. This is documented in
+`com.novell.ldap.client.Debug` but a useful example is to enable API tracing by
+setting the system propery:
+
+    -Dldap.debug=APIRequests
+
+which gives a high level overview of the operations of of the library.
+


### PR DESCRIPTION
This makes the building of the group browser's list of course providers much more reliable:
- It improves the filter so it's much faster now so the problem should occur much less.
- It fixes up the integration tests so they work and test more useful stuff.
- It has a fallback so if we can't find the list of departments providing courses we fallback to showing all providers even if they have no courses.