### PR TITLE
WL-3675 Added method updateUserId() in the UserDirectoryService class of

### DIFF
--- a/integration-tests/src/test/java/uk/ac/ox/oucs/vle/MockUserDirectoryServices.java
+++ b/integration-tests/src/test/java/uk/ac/ox/oucs/vle/MockUserDirectoryServices.java
@@ -54,6 +54,9 @@ public class MockUserDirectoryServices implements UserDirectoryService {
 		// TODO Auto-generated method stub
 		return false;
 	}
+	public boolean updateUserId(String eId, String newEmail) {
+		return false;
+	}
 
 	public boolean allowUpdateUserPassword(String arg0) {
 		// TODO Auto-generated method stub


### PR DESCRIPTION
external-groups.

As this class implements the UserDirectoryService class from kernel where
new method updateUserId() is added, hence implemented the method
to fix the test in the external-groups.